### PR TITLE
Put interval polling information in a separate container to reduce flakiness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 6.0.2', '>= 6.0.2.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 4.3.6'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       thor
       thread_safe
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.8)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
@@ -282,7 +282,7 @@ DEPENDENCIES
   database_cleaner
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
-  puma (~> 4.3)
+  puma (~> 4.3.6)
   rails (~> 6.0.2, >= 6.0.2.2)
   render_async!
   rspec-rails
@@ -301,4 +301,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.2.28

--- a/app/views/render_asyncs/_use_cases.html.erb
+++ b/app/views/render_asyncs/_use_cases.html.erb
@@ -146,13 +146,16 @@
 
     <%= render_async wave_render_async_path,
                      container_id: 'controllable-interval',
-                     interval: 3000 %>
+                     interval: 6000 %>
+
+    <div id='interval-control-info'></div>
 
     <button id='stop-polling'>Stop polling</button>
     <button id='start-polling'>Start polling</button>
 
     <script>
       var container = document.getElementById('controllable-interval')
+      var intervalInfoContainer = document.getElementById('interval-control-info')
       var stopPolling = document.getElementById('stop-polling')
       var startPolling = document.getElementById('start-polling')
 
@@ -163,8 +166,7 @@
       }
 
       stopPolling.addEventListener('click', function() {
-        debugger
-        container.innerHTML = '<p>Polling stopped</p>'
+        intervalInfoContainer.innerHTML = '<p>Polling stopped</p>'
         triggerEventOnContainer('async-stop')
       })
       startPolling.addEventListener('click', function() {

--- a/features/step_definitions/render_async_steps.rb
+++ b/features/step_definitions/render_async_steps.rb
@@ -67,7 +67,7 @@ end
 
 Then("I should see that the polling stopped") do
   within '#toggle-feature-with-event-trigger' do
-    expect(page).to have_text('Polling stopped', wait: 3)
+    expect(page).to have_text('Polling stopped', wait: 5)
   end
 end
 


### PR DESCRIPTION
There was a random failure for interval example.